### PR TITLE
feat(blog): GraphQL fetcher でサーバーサイドとクライアントサイドの URL を分離

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,3 +43,4 @@ jobs:
         run: pnpm build
         env:
           NEXT_PUBLIC_GRAPHQL_ENDPOINT: http://localhost:4000/graphql # Dummy
+          INTERNAL_GRAPHQL_ENDPOINT: http://localhost:4000/graphql # Dummy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,13 @@ pnpm dev
 pnpm build
 
 # 全パッケージでリンティング実行
-pnpm lint
-pnpm lint:fix  # リンティング問題を自動修正
+pnpm lint       # ルートの ESLint のみ実行
+pnpm lint:all   # 全パッケージでリンティング実行
+pnpm lint:apps  # apps 配下のパッケージのみリンティング実行
+pnpm lint:fix   # リンティング問題を自動修正（全パッケージ）
+
+# 総合的なコード品質修正
+pnpm fix        # package.json ソート + リンティング修正 + フォーマット
 
 # コードフォーマット（Prettier）
 pnpm format       # 全ファイルをフォーマット
@@ -34,6 +39,13 @@ pnpm type-check
 
 # テスト実行
 pnpm test
+
+# その他のユーティリティコマンド
+pnpm clear      # ビルド成果物やnode_modulesを削除
+pnpm ncu        # 依存関係の更新確認
+pnpm sort       # package.json のソート
+pnpm sort:check # package.json ソート状態の確認
+pnpm start      # 本番環境での起動
 ```
 
 ### 初期セットアップ
@@ -78,6 +90,8 @@ docker-compose up -d
 - Commitlint による Conventional Commits 形式の強制
 - 全パッケージでのコード品質のための ESLint
 - Prettier によるコードフォーマットの統一（ESLint と競合しない設定）
+- pnpm workspace による効率的な依存関係管理
+- pnpm@10.12.1 以上、Node.js 24.2.0 以上を要求
 
 ## アプリケーション別ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,164 @@
 # White Flask
 
-## 構成
+White Flask は pnpm workspace を使用したモノレポ構造による個人ブログサイトプロジェクトです。
 
-- **apps/blog**: ブログサイト (Next.js)
-- **apps/admin**: 管理画面 (SvelteKit)
-- **apps/backend**: GraphQL API (Pothos + GraphQL Yoga)
+## 🏗️ アーキテクチャ概要
 
-## セットアップ
+### システム構成
 
-```bash
-mise run bootstrap
-# or
-./scripts/bootstrap.sh
+```mermaid
+graph TB
+    subgraph "Frontend Applications"
+        Blog[📝 Next.js Blog<br/>- ブログ表示<br/>- SEO 最適化<br/>- 静的生成]
+        Admin[⚙️ SvelteKit Admin<br/>- コンテンツ管理<br/>- ダッシュボード<br/>- 記事編集]
+    end
 
-# データベースの起動
-docker-compose up -d
+    subgraph "Backend Services"
+        API[🚀 GraphQL API<br/>- Pothos Schema<br/>- GraphQL Yoga<br/>- Drizzle ORM]
+        DB[🗄️ PostgreSQL<br/>- Docker Compose<br/>- 記事データ<br/>- メタデータ]
+    end
 
-# 開発サーバーの起動
-pnpm dev
+    Blog -->|GraphQL Query| API
+    Admin -->|GraphQL Mutation/Query| API
+    API -->|Drizzle ORM| DB
+
+    classDef frontend fill:#e1f5fe
+    classDef backend fill:#f3e5f5
+    classDef database fill:#e8f5e8
+
+    class Blog,Admin frontend
+    class API backend
+    class DB database
 ```
 
-## リンク
+### アプリケーション構成
 
-- https://www.cloudflare.com/
-- https://railway.com/
+- **📝 apps/blog** - 公開ブログサイト (Next.js 15 + React 19)
+- **⚙️ apps/admin** - コンテンツ管理画面 (SvelteKit)
+- **🚀 apps/backend** - GraphQL API サーバー (Pothos + GraphQL Yoga)
+
+### ディレクトリ構造
+
+```
+white-flask/
+├── apps/
+│   ├── blog/           # Next.js ブログサイト
+│   ├── admin/          # SvelteKit 管理画面
+│   └── backend/        # GraphQL API
+├── generated/          # 自動生成共有ファイル（Git 管理対象外）
+├── scripts/            # セットアップスクリプト
+├── package.json        # ワークスペース設定
+├── pnpm-workspace.yaml # pnpm ワークスペース設定
+└── docker-compose.yml  # PostgreSQL データベース
+```
+
+## 🛠️ 技術スタック
+
+### フロントエンド (Blog)
+
+- **Next.js 15.3.4** - React フレームワーク (App Router)
+- **React 19.1.0** - UI ライブラリ
+- **TypeScript 5.8.3** - 静的型付け
+- **GraphQL** - データ取得 (GraphQL Request + SWR)
+- **Feature-Sliced Design v2.1** - アーキテクチャパターン
+
+### バックエンド (API)
+
+- **Pothos** - 型安全な GraphQL スキーマビルダー
+- **GraphQL Yoga** - 高速 GraphQL サーバー
+- **Drizzle ORM** - TypeScript ORM
+- **PostgreSQL** - リレーショナルデータベース
+
+### 管理画面 (Admin)
+
+- **SvelteKit** - フロントエンドフレームワーク
+- **Vite** - ビルドツール
+- **TypeScript** - 静的型付け
+
+### 開発環境
+
+- **pnpm** - パッケージマネージャー (workspace 対応)
+- **Docker Compose** - PostgreSQL コンテナ管理
+- **ESLint + Prettier** - コード品質・フォーマット
+- **Lefthook + Commitlint** - Git フック・コミット規約
+
+## 🎯 設計原則
+
+### モノレポ設計
+
+- **責務分離**: 各アプリケーションは独立した責務を持つ
+- **共通化**: 型定義やスキーマは自動生成で共有
+- **独立デプロイ**: 各アプリケーションは個別にデプロイ可能
+
+### データフロー
+
+```mermaid
+graph LR
+    A[SvelteKit Admin] --> C[GraphQL API]
+    B[Next.js Blog] --> C
+    C --> D[PostgreSQL]
+```
+
+### 型安全性
+
+- **GraphQL Code Generator**: バックエンドスキーマからフロントエンド型定義を自動生成
+- **Pothos**: コードファーストによる型安全な GraphQL スキーマ構築
+- **Drizzle ORM**: TypeScript ネイティブなデータベース操作
+
+## 🏛️ アーキテクチャパターン
+
+### Blog (Feature-Sliced Design)
+
+```
+src/
+├── app/           # Next.js App Router (ルーティング)
+├── views/         # ページコンポジション
+├── widgets/       # 独立した UI ブロック
+├── features/      # ユーザー機能
+├── entities/      # ビジネスエンティティ
+├── shared/        # 共通コンポーネント・ユーティリティ
+└── gql/           # GraphQL 自動生成ファイル
+```
+
+### Backend (レイヤード)
+
+```
+src/
+├── server.ts      # GraphQL Yoga サーバー
+├── schema.ts      # Pothos スキーマ定義
+├── schema/        # データベーススキーマ
+└── libs/          # ユーティリティ
+```
+
+### Admin (SvelteKit 標準)
+
+```
+src/
+├── routes/        # ファイルベースルーティング
+├── lib/           # 共通ロジック
+└── app.html       # HTML テンプレート
+```
+
+## 🔄 開発フロー
+
+### GraphQL 開発サイクル
+
+1. **Backend**: Pothos でスキーマ定義・実装
+2. **スキーマ生成**: `pnpm schema:generate` で SDL 出力
+3. **型生成**: Blog で `pnpm codegen` 実行
+4. **Frontend**: 型安全な GraphQL クライアント実装
+
+### デプロイメント
+
+- **Railway**: 各アプリケーション個別デプロイ (`railway.toml`)
+- **Docker**: PostgreSQL はコンテナで運用
+- **環境分離**: 開発・本番環境の完全分離
+
+## 📖 ドキュメント
+
+プロジェクト詳細は各アプリケーションのドキュメントを参照してください：
+
+- **apps/blog/README.md** - Next.js ブログサイトの詳細
+- **apps/backend/README.md** - GraphQL API の詳細
+- **apps/admin/CLAUDE.md** - SvelteKit 管理画面の詳細
+- **CLAUDE.md** - 開発ガイドライン・設計原則

--- a/apps/blog/.env.example
+++ b/apps/blog/.env.example
@@ -1,2 +1,3 @@
 # GraphQL API endpoint
+INTERNAL_GRAPHQL_ENDPOINT=http://localhost:3003/graphql
 NEXT_PUBLIC_GRAPHQL_ENDPOINT=http://localhost:3003/graphql

--- a/apps/blog/src/app/blog/page.tsx
+++ b/apps/blog/src/app/blog/page.tsx
@@ -1,5 +1,7 @@
 import { BlogListPage } from '@/views/blog'
 
+export const dynamic = 'force-dynamic'
+
 export default function Page() {
   return <BlogListPage />
 }

--- a/apps/blog/src/entities/hello/api/get-hello.ts
+++ b/apps/blog/src/entities/hello/api/get-hello.ts
@@ -1,0 +1,17 @@
+import { graphql } from '@/gql'
+import type { HelloQuery, HelloQueryVariables } from '@/gql/graphql'
+import { graphqlFetcher } from '@/shared/lib'
+
+const HELLO_QUERY = graphql(`
+  query Hello {
+    hello
+  }
+`)
+
+/**
+ * サーバーサイドで hello を取得する関数
+ * Server Components から呼び出される
+ */
+export async function getHello(): Promise<HelloQuery> {
+  return graphqlFetcher<HelloQuery, HelloQueryVariables>(HELLO_QUERY)
+}

--- a/apps/blog/src/entities/hello/index.ts
+++ b/apps/blog/src/entities/hello/index.ts
@@ -1,1 +1,2 @@
 export { useHello } from './api/use-hello'
+export { getHello } from './api/get-hello'

--- a/apps/blog/src/shared/lib/env.ts
+++ b/apps/blog/src/shared/lib/env.ts
@@ -5,12 +5,27 @@ interface Env {
 /**
  * 環境変数を安全に取得するユーティリティ関数
  * 必要な環境変数が設定されていない場合はエラーを投げる
+ *
+ * サーバーサイドでは内部ネットワーク用の URL を使用し、
+ * クライアントサイドでは外部アクセス用の URL を使用する
  */
 export function getEnv(): Env {
-  const graphqlEndpoint = process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT
+  // サーバーサイドでの実行かどうかを判定
+  const isServerSide = typeof window === 'undefined'
+
+  let graphqlEndpoint: string | undefined
+
+  if (isServerSide) {
+    // サーバーサイドでは内部ネットワーク用の URL を使用
+    graphqlEndpoint = process.env.INTERNAL_GRAPHQL_ENDPOINT
+  } else {
+    // クライアントサイドでは外部アクセス用の URL を使用
+    graphqlEndpoint = process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT
+  }
 
   if (!graphqlEndpoint) {
-    throw new Error('NEXT_PUBLIC_GRAPHQL_ENDPOINT environment variable is required')
+    const requiredVar = isServerSide ? 'INTERNAL_GRAPHQL_ENDPOINT' : 'NEXT_PUBLIC_GRAPHQL_ENDPOINT'
+    throw new Error(`${requiredVar} environment variable is required`)
   }
 
   return {

--- a/apps/blog/src/views/blog/ui/BlogListPage.tsx
+++ b/apps/blog/src/views/blog/ui/BlogListPage.tsx
@@ -1,7 +1,14 @@
-export function BlogListPage() {
+import { getHello } from '@/entities/hello'
+
+export async function BlogListPage() {
+  // サーバーサイドで hello クエリをフェッチ
+  const data = await getHello()
+
   return (
     <div>
       <h1>ブログ一覧</h1>
+      <p>サーバーサイドでデータを取得しました</p>
+      <p>GraphQL からの応答: {data?.hello}</p>
       <p>ここにコンテンツ</p>
     </div>
   )


### PR DESCRIPTION
## 概要

GraphQL fetcher でサーバーサイドとクライアントサイドの URL を分離し、サーバーサイドでは内部ネットワーク経由での高速通信を実現しました。

## 関連 Issue

<\!-- 関連するIssueがあれば記載してください -->

## 変更内容

- サーバーサイド実行時は `INTERNAL_GRAPHQL_ENDPOINT` 環境変数を使用
- クライアントサイド実行時は `NEXT_PUBLIC_GRAPHQL_ENDPOINT` 環境変数を使用
- 内部ネットワーク経由でのパフォーマンス向上を実現
- `.env.example` に新しい環境変数 `INTERNAL_GRAPHQL_ENDPOINT` を追加
- `typeof window === 'undefined'` による実行環境判定を実装