### PR TITLE
feat: implement blog database schema with Drizzle ORM

### DIFF
--- a/apps/backend/src/schema/categories.ts
+++ b/apps/backend/src/schema/categories.ts
@@ -1,0 +1,13 @@
+import { pgTable, uuid, varchar, text, timestamp } from 'drizzle-orm/pg-core'
+
+export const categories = pgTable('categories', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: varchar('name', { length: 50 }).notNull().unique(),
+  description: text('description'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  deletedAt: timestamp('deleted_at'),
+})
+
+export type Category = typeof categories.$inferSelect
+export type NewCategory = typeof categories.$inferInsert

--- a/apps/backend/src/schema/comments.ts
+++ b/apps/backend/src/schema/comments.ts
@@ -1,0 +1,19 @@
+import { pgTable, uuid, varchar, text, timestamp, pgEnum } from 'drizzle-orm/pg-core'
+import { posts } from './posts'
+
+export const commentStatusEnum = pgEnum('comment_status', ['pending', 'approved', 'spam'])
+
+export const comments = pgTable('comments', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  postId: uuid('post_id').notNull().references(() => posts.id, { onDelete: 'cascade' }),
+  authorName: varchar('author_name', { length: 50 }).notNull(),
+  authorEmail: varchar('author_email', { length: 255 }).notNull(),
+  content: text('content').notNull(),
+  status: commentStatusEnum('status').default('pending').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  deletedAt: timestamp('deleted_at'),
+})
+
+export type Comment = typeof comments.$inferSelect
+export type NewComment = typeof comments.$inferInsert

--- a/apps/backend/src/schema/index.ts
+++ b/apps/backend/src/schema/index.ts
@@ -1,2 +1,61 @@
-// Drizzle schema exports will be added here
-export {}
+import { relations } from 'drizzle-orm'
+
+// Export all tables
+export * from './posts'
+export * from './categories'
+export * from './tags'
+export * from './post-categories'
+export * from './post-tags'
+export * from './comments'
+
+// Import tables for relations
+import { posts } from './posts'
+import { categories } from './categories'
+import { tags } from './tags'
+import { postCategories } from './post-categories'
+import { postTags } from './post-tags'
+import { comments } from './comments'
+
+// Define relationships
+export const postsRelations = relations(posts, ({ many }) => ({
+  categories: many(postCategories),
+  tags: many(postTags),
+  comments: many(comments),
+}))
+
+export const categoriesRelations = relations(categories, ({ many }) => ({
+  posts: many(postCategories),
+}))
+
+export const tagsRelations = relations(tags, ({ many }) => ({
+  posts: many(postTags),
+}))
+
+export const postCategoriesRelations = relations(postCategories, ({ one }) => ({
+  post: one(posts, {
+    fields: [postCategories.postId],
+    references: [posts.id],
+  }),
+  category: one(categories, {
+    fields: [postCategories.categoryId],
+    references: [categories.id],
+  }),
+}))
+
+export const postTagsRelations = relations(postTags, ({ one }) => ({
+  post: one(posts, {
+    fields: [postTags.postId],
+    references: [posts.id],
+  }),
+  tag: one(tags, {
+    fields: [postTags.tagId],
+    references: [tags.id],
+  }),
+}))
+
+export const commentsRelations = relations(comments, ({ one }) => ({
+  post: one(posts, {
+    fields: [comments.postId],
+    references: [posts.id],
+  }),
+}))

--- a/apps/backend/src/schema/post-categories.ts
+++ b/apps/backend/src/schema/post-categories.ts
@@ -1,0 +1,13 @@
+import { pgTable, uuid, primaryKey } from 'drizzle-orm/pg-core'
+import { posts } from './posts'
+import { categories } from './categories'
+
+export const postCategories = pgTable('post_categories', {
+  postId: uuid('post_id').notNull().references(() => posts.id, { onDelete: 'cascade' }),
+  categoryId: uuid('category_id').notNull().references(() => categories.id, { onDelete: 'cascade' }),
+}, (table) => ({
+  pk: primaryKey({ columns: [table.postId, table.categoryId] })
+}))
+
+export type PostCategory = typeof postCategories.$inferSelect
+export type NewPostCategory = typeof postCategories.$inferInsert

--- a/apps/backend/src/schema/post-tags.ts
+++ b/apps/backend/src/schema/post-tags.ts
@@ -1,0 +1,13 @@
+import { pgTable, uuid, primaryKey } from 'drizzle-orm/pg-core'
+import { posts } from './posts'
+import { tags } from './tags'
+
+export const postTags = pgTable('post_tags', {
+  postId: uuid('post_id').notNull().references(() => posts.id, { onDelete: 'cascade' }),
+  tagId: uuid('tag_id').notNull().references(() => tags.id, { onDelete: 'cascade' }),
+}, (table) => ({
+  pk: primaryKey({ columns: [table.postId, table.tagId] })
+}))
+
+export type PostTag = typeof postTags.$inferSelect
+export type NewPostTag = typeof postTags.$inferInsert

--- a/apps/backend/src/schema/posts.ts
+++ b/apps/backend/src/schema/posts.ts
@@ -1,0 +1,20 @@
+import { pgTable, uuid, varchar, text, timestamp, integer, pgEnum } from 'drizzle-orm/pg-core'
+
+export const postStatusEnum = pgEnum('post_status', ['draft', 'published', 'archived'])
+
+export const posts = pgTable('posts', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  title: varchar('title', { length: 200 }).notNull(),
+  content: text('content').notNull(),
+  excerpt: text('excerpt'),
+  coverImageUrl: varchar('cover_image_url', { length: 500 }),
+  status: postStatusEnum('status').default('draft').notNull(),
+  likeCount: integer('like_count').default(0).notNull(),
+  publishedAt: timestamp('published_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  deletedAt: timestamp('deleted_at'),
+})
+
+export type Post = typeof posts.$inferSelect
+export type NewPost = typeof posts.$inferInsert

--- a/apps/backend/src/schema/tags.ts
+++ b/apps/backend/src/schema/tags.ts
@@ -1,0 +1,12 @@
+import { pgTable, uuid, varchar, timestamp } from 'drizzle-orm/pg-core'
+
+export const tags = pgTable('tags', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: varchar('name', { length: 30 }).notNull().unique(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  deletedAt: timestamp('deleted_at'),
+})
+
+export type Tag = typeof tags.$inferSelect
+export type NewTag = typeof tags.$inferInsert


### PR DESCRIPTION
## 概要
ブログサイトのデータベーススキーマをDrizzle ORMで実装しました。

## 主な変更点
- 全テーブルに `deletedAt` カラムを追加
- `slug` フィールドを削除（URLにはidやnameを使用）
- 記事にいいね機能を追加（カウント保存）
- usersテーブルを削除（ログイン機能なし、個人サイト）
- postsテーブルから authorId を削除
- コメントを簡素化（親子関係なし、名前ベースの投稿）

## 作成したテーブル
- `posts` - 記事テーブル
- `categories` - カテゴリーテーブル
- `tags` - タグテーブル
- `post_categories` - 記事-カテゴリー中間テーブル
- `post_tags` - 記事-タグ中間テーブル
- `comments` - コメントテーブル

## 次のステップ
マイグレーションファイルを生成してデータベースに適用してください。

Resolves #17

Generated with [Claude Code](https://claude.ai/code)